### PR TITLE
Update project URLs in pyproject.toml to reflect correct repository links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/your-username/hls-converter"
-Repository = "https://github.com/your-username/hls-converter.git"
-Documentation = "https://hls-converter.readthedocs.io/"
-"Bug Reports" = "https://github.com/your-username/hls-converter/issues"
+Homepage = "https://github.com/marktennyson/hls-converter"
+Repository = "https://github.com/marktennyson/hls-converter.git"
+Documentation = "https://marktennyson.github.io/hls-converter"
+"Bug Reports" = "https://github.com/marktennyson/hls-converter/issues"
 
 [project.scripts]
 hls-converter = "hls_converter.cli:main"


### PR DESCRIPTION
This pull request updates the project URLs in the `pyproject.toml` file to point to the correct repository and documentation locations.

Repository and documentation updates:

* Updated the `Homepage`, `Repository`, `Documentation`, and `Bug Reports` URLs in `pyproject.toml` to reference the actual `marktennyson/hls-converter` repository and its documentation site.