### PR TITLE
Refactor version handling in setup.py and update CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest pytest-cov
+          pip install .
       - name: Run tests
         run: |
           pytest -q --cov=hls_converter --cov-report=xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hls-converter"
-dynamic = ["version"]
+version = "1.0.0"
 description = "Professional HLS (HTTP Live Streaming) converter with automatic optimization"
 readme = "README.md"
 license = {text = "MIT"}
@@ -62,8 +62,7 @@ Documentation = "https://marktennyson.github.io/hls-converter"
 hls-converter = "hls_converter.cli:main"
 hlsc = "hls_converter.cli:main"
 
-[tool.setuptools.dynamic]
-version = {attr = "hls_converter.__version__"}
+# note: removed dynamic setuptools_scm usage to avoid importing package during build
 
 [tool.setuptools.packages.find]
 exclude = ["tests*", "docs*"]

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,16 @@ this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text(encoding='utf-8') if (this_directory / "README.md").exists() else ""
 
 # Read version from __init__.py
-version = {}
-with open("hls_converter/__init__.py") as fp:
-    exec(fp.read(), version)
+import re
+
+# Safely read the package version without executing package code
+version_file = (this_directory / "hls_converter" / "__init__.py")
+version = {"__version__": "0.0.0"}
+if version_file.exists():
+    content = version_file.read_text(encoding='utf-8')
+    match = re.search(r"^__version__\s*=\s*['\"]([^'\"]+)['\"]", content, re.M)
+    if match:
+        version['__version__'] = match.group(1)
 
 # Read requirements
 requirements = []


### PR DESCRIPTION
This pull request updates the packaging and build configuration for the `hls-converter` project to simplify version management and ensure proper installation during CI. The most significant changes are the switch from dynamic to static versioning, safer version extraction in `setup.py`, and improved CI installation steps.

**Packaging and Version Management:**

* Changed from dynamic versioning in `pyproject.toml` to a static version (`version = "1.0.0"`) and removed the dynamic setuptools_scm usage to avoid importing the package during build. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L65-R65)
* Updated `setup.py` to safely read the package version using a regex instead of executing code from `__init__.py`, preventing accidental import-time side effects.

**Continuous Integration Improvements:**

* Added `pip install .` to the CI workflow in `.github/workflows/ci.yml` to ensure the package is installed before running tests, improving test reliability.